### PR TITLE
[IMP] Update manifest and security permissions

### DIFF
--- a/gpt_core/__manifest__.py
+++ b/gpt_core/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'GPT Core',
-    'version': '1.0',
+    'version': '18.0.1.0',
     'license': 'AGPL-3',
     'summary': 'Core utilities for GPT integration',
     'description': 'Configuration and service layer for OpenAI GPT models.',
@@ -14,7 +14,7 @@
         'data/chatgpt_model_data.xml',
         'views/res_config_settings_views.xml',
     ],
-    'external_dependencies': {'python': ['openai']},
+    'external_dependencies': {'python': ['openai>=1.30.0']},
     'installable': True,
     'application': False,
     'auto_install': False,

--- a/gpt_core/security/ir.model.access.csv
+++ b/gpt_core/security/ir.model.access.csv
@@ -1,3 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-gpt_core.access_chatgpt_model,access_chatgpt_model,model_chatgpt_model,base.group_user,1,1,1,1
-gpt_core.access_gpt_completion_log,access_gpt_completion_log,model_gpt_completion_log,base.group_user,1,0,0,0
+gpt_core.access_chatgpt_model_admin,access_chatgpt_model_admin,model_chatgpt_model,base.group_system,1,0,0,0
+gpt_core.access_chatgpt_model_user,access_chatgpt_model_user,model_chatgpt_model,base.group_user,1,0,0,0
+gpt_core.access_gpt_completion_log_admin,access_gpt_completion_log_admin,model_gpt_completion_log,base.group_system,1,0,1,0
+gpt_core.access_gpt_completion_log_support,access_gpt_completion_log_support,model_gpt_completion_log,base.group_user,1,0,0,0


### PR DESCRIPTION
## Summary
- Align module versioning and OpenAI dependency with Odoo 18 conventions
- Restrict ChatGPT model access to read-only and log create/read permissions for admins
- Confirm consistent `gpt_core.*` configuration parameter prefix

## Testing
- `python -m py_compile gpt_core/__manifest__.py`


------
https://chatgpt.com/codex/tasks/task_e_68a52d212bb48320ab526757d268bc59