### PR TITLE
feat: migrate gpt_core to Responses API

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ La arquitectura es **modular**, manteniendo separación clara de responsabilidad
 
 - **gpt_core**
   - Configuración de API key, modelo, temperatura, límites.
+  - `max_tokens` ahora alimenta `max_output_tokens` de la Responses API.
   - Servicios: `gpt.service.complete()` y `gpt.service.retrieve_and_complete()`.
   - Logs de tokens y coste por conversación.
 

--- a/gpt_core/models/res_config_settings.py
+++ b/gpt_core/models/res_config_settings.py
@@ -10,7 +10,7 @@ class ResConfigSettings(models.TransientModel):
     def _get_default_chatgpt_model(self):
         model_id = False
         try:
-            model_id = self.env.ref('gpt_core.chatgpt_model_gpt_4o_mini').id
+            model_id = self.env.ref('gpt_core.chatgpt_model_gpt_5_nano').id
         except Exception:
             model_id = False
         return model_id
@@ -35,7 +35,7 @@ class ResConfigSettings(models.TransientModel):
     )
     max_tokens = fields.Integer(
         string="Max Tokens",
-        help="Maximum number of tokens to generate",
+        help="Maximum number of output tokens to generate (maps to max_output_tokens)",
         config_parameter="gpt_core.max_tokens",
         default=512,
     )


### PR DESCRIPTION
## Summary
- switch `gpt.service` to OpenAI Responses API with message normalization and token usage mapping
- default to `gpt-5-nano`, resolving stored model IDs and adapting unsupported parameters
- document `max_tokens` mapping in config help and README
- normalize missing roles to `user`, log prompts cleanly, and extract results via `output_text` with attribute-based usage fields

## Testing
- `python -m py_compile $(git ls-files "*.py")`


------
https://chatgpt.com/codex/tasks/task_e_68a5f69995308320902eb866867ab001