### PR TITLE
Set GPT-5-mini defaults and enhance diagnostics

### DIFF
--- a/gpt_core/models/gpt_completion_log.py
+++ b/gpt_core/models/gpt_completion_log.py
@@ -8,13 +8,17 @@ class GPTCompletionLog(models.Model):
     _description = 'GPT Completion Log'
     _order = 'id desc'
 
-    model_name = fields.Char(string='Model')
-    prompt_tokens = fields.Integer()
-    completion_tokens = fields.Integer()
+    model = fields.Char(string='Model')
+    status = fields.Char()
+    incomplete_details_reason = fields.Char()
+    input_tokens = fields.Integer()
+    output_tokens = fields.Integer()
+    reasoning_tokens = fields.Integer()
     total_tokens = fields.Integer()
+    max_output_tokens = fields.Integer()
+    temperature = fields.Float()
     cost = fields.Float(help='Approximate cost in USD')
     currency = fields.Char(default='USD')
     prompt = fields.Text()
     response = fields.Text()
     used_retry = fields.Boolean()
-    used_fallback = fields.Boolean()

--- a/gpt_core/models/res_config_settings.py
+++ b/gpt_core/models/res_config_settings.py
@@ -10,7 +10,7 @@ class ResConfigSettings(models.TransientModel):
     def _get_default_chatgpt_model(self):
         model_id = False
         try:
-            model_id = self.env.ref('gpt_core.chatgpt_model_gpt_5_nano').id
+            model_id = self.env.ref('gpt_core.chatgpt_model_gpt_5_mini').id
         except Exception:
             model_id = False
         return model_id
@@ -37,5 +37,5 @@ class ResConfigSettings(models.TransientModel):
         string="Max Tokens",
         help="Maximum number of output tokens to generate (maps to max_output_tokens)",
         config_parameter="gpt_core.max_tokens",
-        default=512,
+        default=1800,
     )


### PR DESCRIPTION
## Summary
- Default to `gpt-5-mini` with `reasoning.effort`="low" and `max_output_tokens`=1800
- Remove model fallback, emit labeled empty-output error with diagnostics
- Log status, token usage, reasoning tokens, temperature and model in `gpt.completion.log`

## Testing
- `python -m py_compile gpt_core/models/gpt_completion_log.py`
- `python -m py_compile gpt_core/models/gpt_service.py`
- `python -m py_compile gpt_core/models/res_config_settings.py`


------
https://chatgpt.com/codex/tasks/task_e_68a63e2103f4832098e5c8effd978c9e