### PR TITLE
feat: update GPT settings and service for GPT-5

### DIFF
--- a/gpt_core/data/chatgpt_model_data.xml
+++ b/gpt_core/data/chatgpt_model_data.xml
@@ -1,17 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data noupdate="1">
-        <record id="chatgpt_model_gpt_4o" model="chatgpt.model">
-            <field name="name">gpt-4o</field>
-        </record>
-        <record id="chatgpt_model_gpt_4o_mini" model="chatgpt.model">
-            <field name="name">gpt-4o-mini</field>
+        <record id="chatgpt_model_gpt_5" model="chatgpt.model">
+            <field name="name">gpt-5</field>
         </record>
         <record id="chatgpt_model_gpt_5_mini" model="chatgpt.model">
             <field name="name">gpt-5-mini</field>
         </record>
         <record id="chatgpt_model_gpt_5_nano" model="chatgpt.model">
             <field name="name">gpt-5-nano</field>
+        </record>
+        <record id="chatgpt_model_gpt_4_1" model="chatgpt.model">
+            <field name="name">gpt-4.1</field>
+        </record>
+        <record id="chatgpt_model_gpt_4_1_mini" model="chatgpt.model">
+            <field name="name">gpt-4.1-mini</field>
+        </record>
+        <record id="chatgpt_model_gpt_4_1_nano" model="chatgpt.model">
+            <field name="name">gpt-4.1-nano</field>
+        </record>
+        <record id="chatgpt_model_gpt_4o" model="chatgpt.model">
+            <field name="name">gpt-4o</field>
+        </record>
+        <record id="chatgpt_model_gpt_4o_2024_05_13" model="chatgpt.model">
+            <field name="name">gpt-4o-2024-05-13</field>
+        </record>
+        <record id="chatgpt_model_gpt_4o_mini" model="chatgpt.model">
+            <field name="name">gpt-4o-mini</field>
+        </record>
+        <record id="param_gpt_core_reasoning_effort" model="ir.config_parameter">
+            <field name="key">gpt_core.reasoning_effort</field>
+            <field name="value">medium</field>
         </record>
     </data>
 </odoo>

--- a/gpt_core/models/gpt_service.py
+++ b/gpt_core/models/gpt_service.py
@@ -8,10 +8,27 @@ _logger = logging.getLogger(__name__)
 
 
 PRICING = {
-    'gpt-4o': {'prompt': 0.000005, 'completion': 0.000015},
-    'gpt-4o-mini': {'prompt': 0.00000015, 'completion': 0.00000060},
-    'gpt-5-mini': {'prompt': 0.00000050, 'completion': 0.00000150},
-    'gpt-5-nano': {'prompt': 0.00000010, 'completion': 0.00000040},
+    'gpt-5': {
+        'prompt': 0.000000625,
+        'cached_prompt': 0.0000000625,
+        'completion': 0.000005,
+    },
+    'gpt-5-mini': {
+        'prompt': 0.000000125,
+        'cached_prompt': 0.0000000125,
+        'completion': 0.000001,
+    },
+    'gpt-5-nano': {
+        'prompt': 0.000000025,
+        'cached_prompt': 0.0000000025,
+        'completion': 0.0000002,
+    },
+    'gpt-4.1': {'prompt': 0.000001, 'completion': 0.000004},
+    'gpt-4.1-mini': {'prompt': 0.0000002, 'completion': 0.0000008},
+    'gpt-4.1-nano': {'prompt': 0.00000005, 'completion': 0.0000002},
+    'gpt-4o': {'prompt': 0.00000125, 'completion': 0.000005},
+    'gpt-4o-2024-05-13': {'prompt': 0.0000025, 'completion': 0.0000075},
+    'gpt-4o-mini': {'prompt': 0.000000075, 'completion': 0.0000003},
 }
 
 
@@ -40,146 +57,167 @@ class GPTService(models.AbstractModel):
                 model_name = model_rec.name or model_name
             else:
                 model_name = model_param
-        temperature = float(ICP.get_param('gpt_core.temperature') or 0.0)
-        max_tokens = int(ICP.get_param('gpt_core.max_tokens') or 1800)
-        return model_name, temperature, max_tokens
+        temperature = float(ICP.get_param('gpt_core.temperature') or 0.75)
+        max_tokens = int(ICP.get_param('gpt_core.max_tokens') or 1600)
+        reasoning_effort = ICP.get_param('gpt_core.reasoning_effort') or 'medium'
+        return model_name, temperature, max_tokens, reasoning_effort
 
     @api.model
     def chat_completion(self, messages, **kwargs):
         client = self._get_client()
-        model_name, temperature, max_tokens = self._default_params()
+        model_name, temperature, max_tokens, reasoning_effort = self._default_params()
         temperature = kwargs.get('temperature', temperature)
         max_tokens = kwargs.get('max_tokens', max_tokens)
         model_name = kwargs.get('model', model_name)
-        reasoning_effort = kwargs.get('reasoning_effort', 'low')
+        reasoning_effort = kwargs.get('reasoning_effort', reasoning_effort)
 
         def _stringify(content):
             if isinstance(content, list):
                 texts = []
                 for part in content:
                     if isinstance(part, dict) or hasattr(part, 'get'):
-                        texts.append(
-                            getattr(part, 'text', '') or part.get('text', '')
-                        )
+                        texts.append(getattr(part, 'text', '') or part.get('text', ''))
                     else:
-                        texts.append(
-                            getattr(part, 'text', '') or str(part)
-                        )
+                        texts.append(getattr(part, 'text', '') or str(part))
                 return ''.join(texts)
             return content or ''
 
-        prompt = '\n'.join(_stringify(m.get('content', '')) for m in messages)
+        if model_name.startswith('gpt-5'):
+            prompt = '\n'.join(
+                _stringify(m.get('content', '')) for m in messages
+            )
 
-        def _request(m_name, tokens):
-            params = {
-                'model': m_name,
-                'input': prompt,
-                'max_output_tokens': tokens,
-                'reasoning': {'effort': reasoning_effort},
-            }
-            if not m_name.startswith('gpt-5') and temperature is not None:
-                params['temperature'] = temperature
-            try:
-                resp = client.responses.create(**params)
-            except Exception as e:  # adapt unsupported params silently
-                msg = str(e).lower()
-                adapted = False
-                if 'max_tokens' in msg:
-                    params['max_output_tokens'] = params.pop(
-                        'max_tokens', tokens
-                    )
-                    adapted = True
-                if 'temperature' in msg and 'temperature' in params:
-                    params.pop('temperature', None)
-                    adapted = True
-                if adapted:
-                    _logger.info('Adjusted unsupported parameter: %s', e)
+            def _request(m_name, tokens):
+                params = {
+                    'model': m_name,
+                    'input': prompt,
+                    'max_output_tokens': tokens,
+                    'reasoning': {'effort': reasoning_effort},
+                }
+                try:
                     resp = client.responses.create(**params)
-                else:
-                    raise
-            return resp
+                except Exception as e:
+                    msg = str(e).lower()
+                    adapted = False
+                    if 'max_tokens' in msg:
+                        params['max_output_tokens'] = params.pop('max_tokens', tokens)
+                        adapted = True
+                    if 'temperature' in msg and 'temperature' in params:
+                        params.pop('temperature', None)
+                        adapted = True
+                    if adapted:
+                        _logger.info('Adjusted unsupported parameter: %s', e)
+                        resp = client.responses.create(**params)
+                    else:
+                        raise
+                return resp
 
-        def _extract_text(resp):
-            text = getattr(resp, 'output_text', '') or ''
+            def _extract_text(resp):
+                text = getattr(resp, 'output_text', '') or ''
+                if not text.strip():
+                    texts = []
+                    for output in getattr(resp, 'output', []) or []:
+                        content = getattr(output, 'content', None)
+                        if content is None and hasattr(output, 'get'):
+                            content = output.get('content', [])
+                        for part in content or []:
+                            texts.append(getattr(part, 'text', '') or part.get('text', ''))
+                    text = ''.join(texts)
+                return text
+
+            used_retry = False
+            effective_max_tokens = max_tokens
+            response = _request(model_name, max_tokens)
+            _logger.info('Raw response: %s', response.model_dump() if hasattr(response, 'model_dump') else response.__dict__)
+            text = _extract_text(response)
             if not text.strip():
-                texts = []
-                for output in getattr(resp, 'output', []) or []:
-                    content = getattr(output, 'content', None)
-                    if content is None and hasattr(output, 'get'):
-                        content = output.get('content', [])
-                    for part in content or []:
-                        texts.append(
-                            getattr(part, 'text', '') or part.get('text', '')
-                        )
-                text = ''.join(texts)
+                used_retry = True
+                retry_tokens = max(max_tokens, 128)
+                response = _request(model_name, retry_tokens)
+                effective_max_tokens = retry_tokens
+                _logger.info('Raw response (retry): %s', response.model_dump() if hasattr(response, 'model_dump') else response.__dict__)
+                text = _extract_text(response)
+            usage_obj = getattr(response, 'usage', None)
+            usage = {
+                'input_tokens': getattr(usage_obj, 'input_tokens', 0),
+                'output_tokens': getattr(usage_obj, 'output_tokens', 0),
+                'total_tokens': getattr(usage_obj, 'total_tokens', 0),
+                'cached_input_tokens': getattr(usage_obj, 'cached_input_tokens', 0),
+            }
+            if not usage['total_tokens']:
+                usage['total_tokens'] = usage['input_tokens'] + usage['output_tokens']
+            token_details = getattr(response, 'output_tokens_details', None)
+            if not token_details and usage_obj:
+                token_details = getattr(usage_obj, 'output_tokens_details', None)
+            reasoning_tokens = (
+                getattr(token_details, 'reasoning_tokens', 0) if token_details else 0
+            )
+            diagnostics = {
+                'status': getattr(response, 'status', None),
+                'incomplete_details_reason': getattr(getattr(response, 'incomplete_details', None), 'reason', None),
+                'input_tokens': usage['input_tokens'],
+                'output_tokens': usage['output_tokens'],
+                'reasoning_tokens': reasoning_tokens,
+                'max_output_tokens': effective_max_tokens,
+                'temperature': None,
+                'model': model_name,
+            }
+            if not text.strip():
+                raise ValueError('gpt-5 empty_output', diagnostics)
+            self._log_usage(
+                model_name,
+                usage,
+                messages,
+                text,
+                diagnostics,
+                used_retry=used_retry,
+                usage_obj=usage_obj,
+            )
+            return text
+        else:
+            response = client.chat.completions.create(
+                model=model_name,
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+            _logger.info('Raw response: %s', response.model_dump() if hasattr(response, 'model_dump') else response.__dict__)
+            text = ''
+            if getattr(response, 'choices', None):
+                choice = response.choices[0]
+                message = getattr(choice, 'message', None)
+                text = getattr(message, 'content', '') if message else ''
+            usage_obj = getattr(response, 'usage', None)
+            usage = {
+                'input_tokens': getattr(usage_obj, 'prompt_tokens', 0),
+                'output_tokens': getattr(usage_obj, 'completion_tokens', 0),
+                'total_tokens': getattr(usage_obj, 'total_tokens', 0),
+            }
+            if not usage['total_tokens']:
+                usage['total_tokens'] = usage['input_tokens'] + usage['output_tokens']
+            diagnostics = {
+                'status': getattr(response, 'status', None),
+                'incomplete_details_reason': None,
+                'input_tokens': usage['input_tokens'],
+                'output_tokens': usage['output_tokens'],
+                'reasoning_tokens': None,
+                'max_output_tokens': max_tokens,
+                'temperature': temperature,
+                'model': model_name,
+            }
+            if not text.strip():
+                raise ValueError('empty_output', diagnostics)
+            self._log_usage(
+                model_name,
+                usage,
+                messages,
+                text,
+                diagnostics,
+                used_retry=False,
+                usage_obj=usage_obj,
+            )
             return text
 
-        used_retry = False
-        effective_max_tokens = max_tokens
-
-        response = _request(model_name, max_tokens)
-        _logger.info(
-            'Raw response: %s',
-            response.model_dump()
-            if hasattr(response, 'model_dump')
-            else response.__dict__,
-        )
-        text = _extract_text(response)
-
-        if not text.strip():
-            used_retry = True
-            retry_tokens = max(max_tokens, 128)
-            response = _request(model_name, retry_tokens)
-            effective_max_tokens = retry_tokens
-            _logger.info(
-                'Raw response (retry): %s',
-                response.model_dump()
-                if hasattr(response, 'model_dump')
-                else response.__dict__,
-            )
-            text = _extract_text(response)
-
-        usage_obj = getattr(response, 'usage', None)
-        usage = {
-            'input_tokens': getattr(usage_obj, 'input_tokens', 0),
-            'output_tokens': getattr(usage_obj, 'output_tokens', 0),
-            'total_tokens': getattr(usage_obj, 'total_tokens', 0),
-        }
-        if not usage['total_tokens']:
-            usage['total_tokens'] = (
-                usage['input_tokens'] + usage['output_tokens']
-            )
-        token_details = getattr(response, 'output_tokens_details', None)
-        reasoning_tokens = (
-            getattr(token_details, 'reasoning_tokens', 0) if token_details else 0
-        )
-        diagnostics = {
-            'status': getattr(response, 'status', None),
-            'incomplete_details_reason': getattr(
-                getattr(response, 'incomplete_details', None), 'reason', None
-            ),
-            'input_tokens': usage['input_tokens'],
-            'output_tokens': usage['output_tokens'],
-            'reasoning_tokens': reasoning_tokens,
-            'max_output_tokens': effective_max_tokens,
-            'temperature': temperature
-            if not model_name.startswith('gpt-5') and temperature is not None
-            else None,
-            'model': model_name,
-        }
-        _logger.info('Diagnostics: %s', diagnostics)
-        if not text.strip():
-            raise ValueError('gpt-5-nano empty_output', diagnostics)
-
-        self._log_usage(
-            model_name,
-            usage,
-            messages,
-            text,
-            diagnostics,
-            used_retry=used_retry,
-        )
-        return text
 
     @api.model
     def _log_usage(
@@ -190,8 +228,16 @@ class GPTService(models.AbstractModel):
         response,
         diagnostics,
         used_retry=False,
+        usage_obj=None,
     ):
         prompt_tokens = usage.get('input_tokens', 0)
+        cached_tokens = usage.get('cached_input_tokens', 0)
+        if not cached_tokens and usage_obj:
+            cached_tokens = getattr(
+                getattr(usage_obj, 'input_tokens_details', None),
+                'cached_tokens',
+                0,
+            )
         completion_tokens = usage.get('output_tokens', 0)
         total_tokens = usage.get(
             'total_tokens', prompt_tokens + completion_tokens
@@ -199,6 +245,7 @@ class GPTService(models.AbstractModel):
         pricing = PRICING.get(model_name, {})
         cost = (
             prompt_tokens * pricing.get('prompt', 0)
+            + cached_tokens * pricing.get('cached_prompt', 0)
             + completion_tokens * pricing.get('completion', 0)
         )
 

--- a/gpt_core/views/res_config_settings_views.xml
+++ b/gpt_core/views/res_config_settings_views.xml
@@ -5,42 +5,75 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//form" position="inside">
-                <div class="app_settings_block" data-string="GPT" string="GPT" data-key="gpt_core">
-                    <h2>GPT</h2>
-                    <div class="col-xs-12 row o_settings_container o_gpt_core_container">
-                        <div class="col-xs-12 col-md-6 o_setting_box">
-                            <div class="o_setting_right_pane border-start-0">
-                                <div class="content-group">
-                                    <div class="row mt8">
-                                        <label class="col-lg-3" string="API Key" for="openapi_api_key"/>
-                                        <field name="openapi_api_key" title="OpenAI API Key"/>
-                                    </div>
-                                </div>
+            <xpath expr="//div[@data-key='base_setup.integration']/div[@class='o_setting_box'][1]" position="after">
+                <field name="is_gpt5" invisible="1"/>
+                <div class="o_setting_box" groups="base.group_system" data-gpt-block="1">
+                    <div class="o_setting_left_pane"/>
+                    <div class="o_setting_right_pane">
+                        <span class="o_form_label">GPT</span>
+                        <div class="text-muted">OpenAI integration</div>
+                        <div class="content-group mt16">
+                            <div class="row mt8">
+                                <label class="col-lg-3" string="API Key" for="openapi_api_key"/>
+                                <field name="openapi_api_key" title="OpenAI API Key"/>
                             </div>
                         </div>
-                        <div class="col-xs-12 col-md-6 o_setting_box">
-                            <div class="o_setting_left_pane"/>
-                            <div class="o_setting_right_pane">
-                                <span class="o_form_label">ChatGPT Model</span>
-                                <div class="text-muted">
-                                    Model for the ChatGPT request
-                                </div>
-                                <div class="content-group mt16">
-                                    <field name="chatgpt_model_id"/>
-                                </div>
-                                <div class="content-group mt16">
-                                    <div class="row">
-                                        <label class="col-lg-3" string="Temperature" for="temperature"/>
-                                        <field name="temperature"/>
-                                    </div>
-                                </div>
-                                <div class="content-group mt16">
-                                    <div class="row">
-                                        <label class="col-lg-3" string="Max Tokens" for="max_tokens"/>
-                                        <field name="max_tokens"/>
-                                    </div>
-                                </div>
+                        <div class="content-group mt16">
+                            <field name="chatgpt_model_id"/>
+                        </div>
+                        <div class="content-group mt16" attrs="{'invisible':[('is_gpt5','=',True)]}">
+                            <div class="row">
+                                <label class="col-lg-3" string="Temperature" for="temperature"/>
+                                <field name="temperature" placeholder="0.75" help="Sampling temperature (GPT-4*)"/>
+                            </div>
+                        </div>
+                        <div class="content-group mt16" attrs="{'invisible':[('is_gpt5','=',False)]}">
+                            <div class="row">
+                                <label class="col-lg-3" string="Reasoning Effort" for="reasoning_effort"/>
+                                <field name="reasoning_effort" placeholder="medium" help="Allocate tokens to reasoning (GPT-5*)"/>
+                            </div>
+                        </div>
+                        <div class="content-group mt16">
+                            <div class="row">
+                                <label class="col-lg-3" string="Max Tokens" for="max_tokens"/>
+                                <field name="max_tokens" placeholder="1600" help="Maximum output tokens (Responses: max_output_tokens / Chat: max_tokens)"/>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+            <xpath expr="//div[@data-key='base_setup.integration'][not(.//div[@data-gpt-block])]" position="inside">
+                <field name="is_gpt5" invisible="1"/>
+                <div class="o_setting_box" groups="base.group_system" data-gpt-block="1">
+                    <div class="o_setting_left_pane"/>
+                    <div class="o_setting_right_pane">
+                        <span class="o_form_label">GPT</span>
+                        <div class="text-muted">OpenAI integration</div>
+                        <div class="content-group mt16">
+                            <div class="row mt8">
+                                <label class="col-lg-3" string="API Key" for="openapi_api_key"/>
+                                <field name="openapi_api_key" title="OpenAI API Key"/>
+                            </div>
+                        </div>
+                        <div class="content-group mt16">
+                            <field name="chatgpt_model_id"/>
+                        </div>
+                        <div class="content-group mt16" attrs="{'invisible':[('is_gpt5','=',True)]}">
+                            <div class="row">
+                                <label class="col-lg-3" string="Temperature" for="temperature"/>
+                                <field name="temperature" placeholder="0.75" help="Sampling temperature (GPT-4*)"/>
+                            </div>
+                        </div>
+                        <div class="content-group mt16" attrs="{'invisible':[('is_gpt5','=',False)]}">
+                            <div class="row">
+                                <label class="col-lg-3" string="Reasoning Effort" for="reasoning_effort"/>
+                                <field name="reasoning_effort" placeholder="medium" help="Allocate tokens to reasoning (GPT-5*)"/>
+                            </div>
+                        </div>
+                        <div class="content-group mt16">
+                            <div class="row">
+                                <label class="col-lg-3" string="Max Tokens" for="max_tokens"/>
+                                <field name="max_tokens" placeholder="1600" help="Maximum output tokens (Responses: max_output_tokens / Chat: max_tokens)"/>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- place GPT configuration under Settings > Integrations with dynamic fields
- extend model catalog and defaults for GPT-5 and GPT-4.1 families
- upgrade service to choose Responses or Chat Completions API with updated pricing
- add cached-token pricing and UI/XPath robustness

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(find gpt_core -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a6496d1dcc83209a789ecd2f1ccff7