### PR TITLE
Fix XPath lookup for GPT settings in Odoo 18

### DIFF
--- a/gpt_core/views/res_config_settings_views.xml
+++ b/gpt_core/views/res_config_settings_views.xml
@@ -5,7 +5,7 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@data-key='base_setup.integration']/div[@class='o_setting_box'][1]" position="after">
+            <xpath expr="//div[@data-key='base_setup.integration']//div[hasclass('o_setting_box')][1]" position="after">
                 <field name="is_gpt5" invisible="1"/>
                 <div class="o_setting_box" groups="base.group_system" data-gpt-block="1">
                     <div class="o_setting_left_pane"/>


### PR DESCRIPTION
## Summary
- Ensure GPT configuration block is injected reliably by using `hasclass('o_setting_box')` in settings view XPath

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `xmllint --noout gpt_core/views/res_config_settings_views.xml`

------
https://chatgpt.com/codex/tasks/task_e_68a65aac9a7c8320a3e6e9d13205f385