### PR TITLE
Fix GPT settings view for Odoo 18 block structure

### DIFF
--- a/gpt_core/views/res_config_settings_views.xml
+++ b/gpt_core/views/res_config_settings_views.xml
@@ -5,79 +5,37 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@data-key='base_setup.integration']/div[@class='o_setting_box'][1]" position="after">
-                <field name="is_gpt5" invisible="1"/>
-                <div class="o_setting_box" groups="base.group_system" data-gpt-block="1">
-                    <div class="o_setting_left_pane"/>
-                    <div class="o_setting_right_pane">
-                        <span class="o_form_label">GPT</span>
-                        <div class="text-muted">OpenAI integration</div>
-                        <div class="content-group mt16">
-                            <div class="row mt8">
-                                <label class="col-lg-3" string="API Key" for="openapi_api_key"/>
-                                <field name="openapi_api_key" title="OpenAI API Key"/>
-                            </div>
-                        </div>
-                        <div class="content-group mt16">
-                            <field name="chatgpt_model_id"/>
-                        </div>
-                        <div class="content-group mt16" attrs="{'invisible':[('is_gpt5','=',True)]}">
-                            <div class="row">
-                                <label class="col-lg-3" string="Temperature" for="temperature"/>
-                                <field name="temperature" placeholder="0.75" help="Sampling temperature (GPT-4*)"/>
-                            </div>
-                        </div>
-                        <div class="content-group mt16" attrs="{'invisible':[('is_gpt5','=',False)]}">
-                            <div class="row">
-                                <label class="col-lg-3" string="Reasoning Effort" for="reasoning_effort"/>
-                                <field name="reasoning_effort" placeholder="medium" help="Allocate tokens to reasoning (GPT-5*)"/>
-                            </div>
-                        </div>
-                        <div class="content-group mt16">
-                            <div class="row">
-                                <label class="col-lg-3" string="Max Tokens" for="max_tokens"/>
-                                <field name="max_tokens" placeholder="1600" help="Maximum output tokens (Responses: max_output_tokens / Chat: max_tokens)"/>
-                            </div>
+            <xpath expr="//block[@name='integration']" position="inside">
+                <setting id="gpt_core_setting" string="GPT" groups="base.group_system">
+                    <field name="is_gpt5" invisible="1"/>
+                    <div class="content-group mt16">
+                        <div class="row mt8">
+                            <label class="col-lg-3" string="API Key" for="openapi_api_key"/>
+                            <field name="openapi_api_key" title="OpenAI API Key"/>
                         </div>
                     </div>
-                </div>
-            </xpath>
-            <xpath expr="//div[@data-key='base_setup.integration'][not(.//div[@data-gpt-block])]" position="inside">
-                <field name="is_gpt5" invisible="1"/>
-                <div class="o_setting_box" groups="base.group_system" data-gpt-block="1">
-                    <div class="o_setting_left_pane"/>
-                    <div class="o_setting_right_pane">
-                        <span class="o_form_label">GPT</span>
-                        <div class="text-muted">OpenAI integration</div>
-                        <div class="content-group mt16">
-                            <div class="row mt8">
-                                <label class="col-lg-3" string="API Key" for="openapi_api_key"/>
-                                <field name="openapi_api_key" title="OpenAI API Key"/>
-                            </div>
-                        </div>
-                        <div class="content-group mt16">
-                            <field name="chatgpt_model_id"/>
-                        </div>
-                        <div class="content-group mt16" attrs="{'invisible':[('is_gpt5','=',True)]}">
-                            <div class="row">
-                                <label class="col-lg-3" string="Temperature" for="temperature"/>
-                                <field name="temperature" placeholder="0.75" help="Sampling temperature (GPT-4*)"/>
-                            </div>
-                        </div>
-                        <div class="content-group mt16" attrs="{'invisible':[('is_gpt5','=',False)]}">
-                            <div class="row">
-                                <label class="col-lg-3" string="Reasoning Effort" for="reasoning_effort"/>
-                                <field name="reasoning_effort" placeholder="medium" help="Allocate tokens to reasoning (GPT-5*)"/>
-                            </div>
-                        </div>
-                        <div class="content-group mt16">
-                            <div class="row">
-                                <label class="col-lg-3" string="Max Tokens" for="max_tokens"/>
-                                <field name="max_tokens" placeholder="1600" help="Maximum output tokens (Responses: max_output_tokens / Chat: max_tokens)"/>
-                            </div>
+                    <div class="content-group mt16">
+                        <field name="chatgpt_model_id"/>
+                    </div>
+                    <div class="content-group mt16" attrs="{'invisible':[('is_gpt5','=',True)]}">
+                        <div class="row">
+                            <label class="col-lg-3" string="Temperature" for="temperature"/>
+                            <field name="temperature" placeholder="0.75" help="Sampling temperature (GPT-4*)"/>
                         </div>
                     </div>
-                </div>
+                    <div class="content-group mt16" attrs="{'invisible':[('is_gpt5','=',False)]}">
+                        <div class="row">
+                            <label class="col-lg-3" string="Reasoning Effort" for="reasoning_effort"/>
+                            <field name="reasoning_effort" placeholder="medium" help="Allocate tokens to reasoning (GPT-5*)"/>
+                        </div>
+                    </div>
+                    <div class="content-group mt16">
+                        <div class="row">
+                            <label class="col-lg-3" string="Max Tokens" for="max_tokens"/>
+                            <field name="max_tokens" placeholder="1600" help="Maximum output tokens (Responses: max_output_tokens / Chat: max_tokens)"/>
+                        </div>
+                    </div>
+                </setting>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
## Summary
- Inject GPT configuration using Odoo 18's `block`/`setting` layout under the Integrations section

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `xmllint --noout gpt_core/views/res_config_settings_views.xml`


------
https://chatgpt.com/codex/tasks/task_e_68a65aac9a7c8320a3e6e9d13205f385